### PR TITLE
Generate enum sql function

### DIFF
--- a/generate/toSqlEnumTable.dhall
+++ b/generate/toSqlEnumTable.dhall
@@ -1,0 +1,57 @@
+let Map = (../Prelude.dhall).Map.Type
+
+let concatMapSep = (../Prelude.dhall).Text.concatMapSep
+
+let Label = ../types/Label.dhall
+
+let Enum = ../types/Enum.dhall
+
+let GraphQL = ../package.dhall
+
+let Entry = { mapKey : Text, mapValue : Label }
+
+let entryToText =
+    \(entry : Entry) ->
+        ''
+        ('${entry.mapKey}', '${merge { None = "", Some = \(t : Text) -> t } entry.mapValue.comment}')
+        ''
+
+-- TODO: convert data.name to snake case
+let toSqlEnumTable =
+    \(data : Enum) ->
+        ''
+        -- AUTO GENERATED FROM .dhall FILE, DO NOT EDIT MANUALLY
+
+        begin;
+
+            create table if not exists public.${data.name} (
+                name text_100 not null primary key,
+                comment text not null
+            );
+
+            insert into public.${data.name}
+                (name, comment)
+                values
+                ${concatMapSep "," Entry entryToText data.labels}
+                on conflict do nothing;
+
+        commit;
+        ''
+
+
+let country =
+    -- GraphQL.Enum.new
+        GraphQL.Enum::{
+        , name = "payment_method"
+        , comment = Some "Supported countries"
+        , labels = toMap
+            { DK = GraphQL.Label::{ name = "DK" }
+            , IS = GraphQL.Label::{ name = "IS" }
+            , NO = GraphQL.Label::{ name = "NO" }
+            , SE = GraphQL.Label::{ name = "SE", comment = Some "number 1" }
+            }
+        }
+
+
+in  { country = toSqlEnumTable country
+    }

--- a/generate/toSqlEnumTable.dhall
+++ b/generate/toSqlEnumTable.dhall
@@ -6,8 +6,6 @@ let Label = ../types/Label.dhall
 
 let Enum = ../types/Enum.dhall
 
-let GraphQL = ../package.dhall
-
 let Entry = { mapKey : Text, mapValue : Label }
 
 let entryToText =
@@ -16,20 +14,19 @@ let entryToText =
         ('${entry.mapKey}', '${merge { None = "", Some = \(t : Text) -> t } entry.mapValue.comment}')
         ''
 
--- TODO: convert data.name to snake case
-let toSqlEnumTable =
+in
     \(data : Enum) ->
         ''
         -- AUTO GENERATED FROM .dhall FILE, DO NOT EDIT MANUALLY
 
         begin;
 
-            create table if not exists public.${data.name} (
+            create table if not exists public.${data.tableName} (
                 name text_100 not null primary key,
                 comment text not null
             );
 
-            insert into public.${data.name}
+            insert into public.${data.tableName}
                 (name, comment)
                 values
                 ${concatMapSep "," Entry entryToText data.labels}
@@ -37,21 +34,3 @@ let toSqlEnumTable =
 
         commit;
         ''
-
-
-let country =
-    -- GraphQL.Enum.new
-        GraphQL.Enum::{
-        , name = "payment_method"
-        , comment = Some "Supported countries"
-        , labels = toMap
-            { DK = GraphQL.Label::{ name = "DK" }
-            , IS = GraphQL.Label::{ name = "IS" }
-            , NO = GraphQL.Label::{ name = "NO" }
-            , SE = GraphQL.Label::{ name = "SE", comment = Some "number 1" }
-            }
-        }
-
-
-in  { country = toSqlEnumTable country
-    }

--- a/types/Enum.dhall
+++ b/types/Enum.dhall
@@ -2,4 +2,4 @@ let Map = (../Prelude.dhall).Map.Type
 
 let Label = ./Label.dhall
 
-in  { name : Text, comment : Optional Text, labels : Map Text Label }
+in  { name : Text, tableName : Text, comment : Optional Text, labels : Map Text Label }


### PR DESCRIPTION
Add a function, `toSqlEnumTable`, that generates a table declaration from an enum.

E.g.
```sql
-- AUTO GENERATED FROM .dhall FILE, DO NOT EDIT MANUALLY

begin;

    create table if not exists public.temp_country_table (
        name text_100 not null primary key,
        comment text not null
    );

    insert into public.temp_country_table
        (name, comment)
        values
        ('DK', '')
,('IS', '')
,('NO', '')
,('SE', 'number 1')

        on conflict do nothing;

commit;
```

It was unfortunately necessary to add a `tableName` field to the enum declarations. The regular names are all written in Pascal case and there's no way in Dhall to convert from Pascal case to snake case.